### PR TITLE
Upgrade to .NET 10 and Add Escaped Database Object Name Helper

### DIFF
--- a/Kull.Data.Test/DBObjectNameTest.cs
+++ b/Kull.Data.Test/DBObjectNameTest.cs
@@ -33,5 +33,30 @@ namespace Kull.Data.Test
             DBObjectName dBObjectName = new DBObjectName("dbo", "taes saf");
             Assert.AreEqual(dBObjectName.ToString(false, true), "dbo.\"taes saf\"");
         }
+
+        [TestMethod]
+        public void TestEscapedDbObjectName()
+        {
+            DBObjectName dBObjectName = new DBObjectName("dbo", "BulkInsert");
+            Assert.AreEqual(dBObjectName.GetEscapedDbObjectName(false), "[dbo].[BulkInsert]");
+        }
+        [TestMethod]
+        public void TestEscapedDbObjectNameWithDots()
+        {
+            DBObjectName dBObjectName = new DBObjectName("Sales.DataDelivery", "BulkInsert.2025");
+            Assert.AreEqual(dBObjectName.GetEscapedDbObjectName(false), "[Sales.DataDelivery].[BulkInsert.2025]");
+        }
+        [TestMethod]
+        public void TestEscapedDbObjectNameWithDotsEmptyDB()
+        {
+            DBObjectName dBObjectName = new DBObjectName("Sales.DataDelivery", "BulkInsert.2025");
+            Assert.AreEqual(dBObjectName.GetEscapedDbObjectName(true), "[Sales.DataDelivery].[BulkInsert.2025]");
+        }
+        [TestMethod]
+        public void TestEscapedDbObjectNameWithDotsDB()
+        {
+            DBObjectName dBObjectName = new DBObjectName("Sales.DataDelivery", "BulkInsert.2025", "Kull");
+            Assert.AreEqual(dBObjectName.GetEscapedDbObjectName(true), "[Kull].[Sales.DataDelivery].[BulkInsert.2025]");
+        }
     }
 }

--- a/Kull.Data.Test/Kull.Data.Test.csproj
+++ b/Kull.Data.Test/Kull.Data.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Kull.Data.Test</RootNamespace>
     <Nullable>enable</Nullable>
 
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.117" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Kull.Data/DBObjectName.cs
+++ b/Kull.Data/DBObjectName.cs
@@ -321,7 +321,7 @@ namespace Kull.Data
         /// </summary>
         /// <param name="withDatabase">Enable to get also the database, e.g. '[master].[dbo].[people]'</param>
         /// <returns>a string with the escaped database object with square brackets</returns>
-        public string GetEscapedDbObjectName(bool withDatabase)
+        public string GetEscapedDbObjectName(bool withDatabase = false)
         {
             string schemaRemovedBracket = (this.Schema ?? "dbo").Replace("[", "").Replace("]", "");
             string tableNameRemovedBracket = this.Name.Replace("[", "").Replace("]", "");

--- a/Kull.Data/DBObjectName.cs
+++ b/Kull.Data/DBObjectName.cs
@@ -82,7 +82,7 @@ namespace Kull.Data
                 return "\"" + input.Replace("\"", "\"\"") + "\"";
             for (int i = 0; i < input.Length; i++)
             {
-                if(i==0 && (input[0] == '#'|| input[0] == '@'))
+                if (i == 0 && (input[0] == '#' || input[0] == '@'))
                 {
                     continue;//Ok to start with # or @ (temp table / table variables)
                 }
@@ -309,6 +309,29 @@ namespace Kull.Data
         public static bool operator >=(DBObjectName? left, DBObjectName? right)
         {
             return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.CompareTo(right) >= 0;
+        }
+
+
+        /// <summary>
+        /// Method which escapes the schema and table name with square brackets.
+        /// Created because to enable dots in the schema name
+        /// Example [dbo].[Accounts]
+        /// 
+        /// Precondition: the database, schema nor the table could have a square bracket in the name 
+        /// </summary>
+        /// <param name="withDatabase">Enable to get also the database, e.g. '[master].[dbo].[people]'</param>
+        /// <returns>a string with the escaped database object with square brackets</returns>
+        public string GetEscapedDbObjectName(bool withDatabase)
+        {
+            string schemaRemovedBracket = (this.Schema ?? "dbo").Replace("[", "").Replace("]", "");
+            string tableNameRemovedBracket = this.Name.Replace("[", "").Replace("]", "");
+            if (withDatabase && !string.IsNullOrEmpty(this.DataBaseName) && !string.IsNullOrWhiteSpace(this.DataBaseName))
+            {
+                string databaseRemovedBracket = this.DataBaseName?.Replace("[", "").Replace("]", "");
+
+                return $"[{databaseRemovedBracket}].[{schemaRemovedBracket}].[{tableNameRemovedBracket}]";
+            }
+            return $"[{schemaRemovedBracket}].[{tableNameRemovedBracket}]";
         }
     }
 }

--- a/Kull.Data/Kull.Data.csproj
+++ b/Kull.Data/Kull.Data.csproj
@@ -2,9 +2,9 @@
 
 	<PropertyGroup>
 		<Description>Kull.Data Class Library</Description>
-		<Version>8.0.1</Version>
+		<Version>10.1.0</Version>
 		<Authors>ehrsam, patrone</Authors>
-		<TargetFrameworks>net47;netstandard2.0;netstandard2.1;net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net47;netstandard2.0;netstandard2.1;net48;net8.0;net10.0</TargetFrameworks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<AssemblyName>Kull.Data</AssemblyName>
@@ -20,7 +20,7 @@
 		<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<RepositoryUrl>https://github.com/Kull-AG/kull-data</RepositoryUrl>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>14.0</LangVersion>
 		<Deterministic>True</Deterministic>
 		<Copyright>Kull AG</Copyright>
 		<IncludeSymbols>true</IncludeSymbols>
@@ -75,16 +75,12 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0"></PackageReference>
 		<PackageReference Include="IsExternalInit" Version="1.0.1"></PackageReference>
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0"></PackageReference>
-	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
 		<PackageReference Include="TimeZoneConverter" Version="3.1.0" />
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' "> 
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"></PackageReference>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'  "> 
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0"></PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<None Remove="stylecop.json" />

--- a/Kull.Data/TimezoneMapping.cs
+++ b/Kull.Data/TimezoneMapping.cs
@@ -45,7 +45,7 @@ namespace Kull.Data
             }
             try
             {
-#if NET6_0 // In .Net 6 unix id's should work
+#if NET8_0_OR_GREATER // In .Net 8 or greater unix id's should work
 
                 if (System.Environment.OSVersion.Platform == PlatformID.Win32NT && TimeZoneInfo.TryConvertIanaIdToWindowsId(value.Trim(), out string? winId))
                     return TimeZoneInfo.FindSystemTimeZoneById(winId);
@@ -59,7 +59,7 @@ namespace Kull.Data
             catch (System.TimeZoneNotFoundException)
             {
                 var sysTimeZones = System.TimeZoneInfo.GetSystemTimeZones();
-                var utcOffset = value.StartsWith("(UTC") ? TimeSpan.Parse(value.Substring("(UTC+".Length-1, "+01:00".Length).Replace("+", "")) : (TimeSpan?)null;
+                var utcOffset = value.StartsWith("(UTC") ? TimeSpan.Parse(value.Substring("(UTC+".Length - 1, "+01:00".Length).Replace("+", "")) : (TimeSpan?)null;
                 var towns = value.Contains(" ") ? value.Substring(value.IndexOf(" ")).Split(',').Select(s => s.Trim()).ToArray() : Array.Empty<string>();
                 foreach (var st in sysTimeZones)
                 {


### PR DESCRIPTION
Upgrade to .NET 10 and introduce the `GetEscapedDbObjectName()` method to safely retrieve schema and table names with square-bracket escaping.