### PR TITLE
Add uppercase environment variable lookup for Linux compatibility

### DIFF
--- a/Kull.Data/DatabaseUtils.cs
+++ b/Kull.Data/DatabaseUtils.cs
@@ -578,12 +578,12 @@ namespace Kull.Data
         /// <returns></returns>
         public static DbConnection GetConnectionFromConfig(string configName)
         {
-            string env = Environment.GetEnvironmentVariable("ASPNETCORE_Environment");
+            string env = Environment.GetEnvironmentVariable("ASPNETCORE_Environment") ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
 
             var builder = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
                 .SetBasePath(System.IO.Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", true, false);
-            if(env != null)
+            if (env != null)
             {
                 builder.AddJsonFile($"appsettings.{env}.json", true, false);
             }
@@ -622,8 +622,8 @@ namespace Kull.Data
                 .SetBasePath(System.IO.Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", true, false);
 
-            string env = Environment.GetEnvironmentVariable("ASPNETCORE_Environment");
-            if(env != null)
+            string env = Environment.GetEnvironmentVariable("ASPNETCORE_Environment") ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"); ;
+            if (env != null)
             {
                 builder.AddJsonFile($"appsettings.{env}.json", true, false);
             }


### PR DESCRIPTION
The environment variable for defining the .NET Core environment is conventionally uppercase: ASPNETCORE_ENVIRONMENT.
The current implementation in DatabaseUtils.cs only checks the lowercase variation "ASPNETCORE_Environment", which works on Windows but not on Linux-based systems due to case sensitivity.

This PR updates the code to check for the lowercase value first and then fall back to the uppercase environment variable to ensure cross-platform compatibility. (Fixes #10)